### PR TITLE
Xsheet interface tweaks

### DIFF
--- a/app/ui/xsheet.ui
+++ b/app/ui/xsheet.ui
@@ -18,10 +18,13 @@
    <bool>false</bool>
   </property>
   <property name="windowTitle">
-   <string>Xsheet</string>
+   <string>X-Sheet</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout_4">
+    <property name="spacing">
+     <number>-1</number>
+    </property>
     <property name="leftMargin">
      <number>2</number>
     </property>
@@ -33,12 +36,24 @@
     </property>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>12</number>
+      </property>
+      <property name="rightMargin">
+       <number>12</number>
+      </property>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QLabel" name="labKeyframes">
           <property name="text">
-           <string>Keys:</string>
+           <string>&lt;span style=&quot; text-decoration: underline;&quot;&gt;Keys&lt;/span&gt;</string>
           </property>
          </widget>
         </item>
@@ -93,19 +108,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </item>
        </layout>
@@ -125,10 +127,13 @@
       </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QLabel" name="labLipsync">
           <property name="text">
-           <string>Lipsync:</string>
+           <string>&lt;span style=&quot; text-decoration: underline;&quot;&gt;Lipsync&lt;/span&gt;</string>
           </property>
          </widget>
         </item>
@@ -229,19 +234,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="horizontalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </item>
        </layout>
@@ -261,10 +253,13 @@
       </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QLabel" name="labCsv">
           <property name="text">
-           <string notr="true">Csv:</string>
+           <string notr="true">&lt;span style=&quot; text-decoration: underline;&quot;&gt;CSV&lt;/span&gt;</string>
           </property>
          </widget>
         </item>
@@ -277,7 +272,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Export xsheet to csv</string>
+           <string>Export x-sheet to CSV</string>
           </property>
           <property name="text">
            <string/>


### PR DESCRIPTION
Changes:
- Underline button labels
- Remove ':' from button labels
- Add left and right margin for buttons
- Remove extra horizontal spacers
- Capitalize CSV (acronym)
- Change xsheet to x-sheet. This seems to be the more common
  spelling online
- Remove spacing between the and buttons

Before:
![screen shot 2018-11-12 at 6 38 12 pm](https://user-images.githubusercontent.com/3461051/48385033-24bd1380-e6aa-11e8-89be-528919371a9c.png)

After:
![screen shot 2018-11-12 at 6 37 26 pm](https://user-images.githubusercontent.com/3461051/48385041-2981c780-e6aa-11e8-99d5-a8f864e43806.png)