### PR TITLE
Fix layer gutter inaccurate painting

### DIFF
--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -154,6 +154,11 @@ void TimeLineCells::updateContent()
     update();
 }
 
+
+bool TimeLineCells::didDetatchLayer() {
+    return abs(getMouseMoveY()) > mLayerDetatchThreshold;
+}
+
 void TimeLineCells::drawContent()
 {
     if (mCache == nullptr)
@@ -206,7 +211,7 @@ void TimeLineCells::drawContent()
             }
         }
     }
-    if (abs(getMouseMoveY()) > 5)
+    if (didDetatchLayer())
     {
         if (mType == TIMELINE_CELL_TYPE::Tracks)
         {
@@ -220,9 +225,9 @@ void TimeLineCells::drawContent()
             layer->paintLabel(painter, this,
                               0, getLayerY(mEditor->layers()->currentLayerIndex()) + getMouseMoveY(),
                               width() - 1, getLayerHeight(), true, mEditor->allLayers());
+
+            paintLayerGutter(painter);
         }
-        painter.setPen(Qt::black);
-        painter.drawRect(0, getLayerY(getLayerNumber(mEndY)) - 1, width(), 2);
     }
     else
     {
@@ -315,6 +320,19 @@ void TimeLineCells::drawContent()
         // --- draw left border line
         painter.setPen(Qt::darkGray);
         painter.drawLine(0, 0, 0, height());
+    }
+}
+
+void TimeLineCells::paintLayerGutter(QPainter& painter)
+{
+    painter.setPen(Qt::black);
+    if (getMouseMoveY() > mLayerDetatchThreshold)
+    {
+        painter.drawRect(0, getLayerY(getLayerNumber(mEndY))+mLayerHeight, width(), 2);
+    }
+    else
+    {
+        painter.drawRect(0, getLayerY(getLayerNumber(mEndY)), width(), 2);
     }
 }
 

--- a/core_lib/src/interface/timelinecells.h
+++ b/core_lib/src/interface/timelinecells.h
@@ -60,6 +60,8 @@ public:
 
     int getFrameSize() { return mFrameSize; }
     void clearCache() { if ( mCache ) delete mCache; mCache = new QPixmap( size() ); }
+    void paintLayerGutter(QPainter& painter);
+    bool didDetatchLayer();
 
 Q_SIGNALS:
     void mouseMovedY(int);
@@ -126,6 +128,7 @@ private:
 
     const static int mOffsetX = 0;
     const static int mOffsetY = 20;
+    const static int mLayerDetatchThreshold = 5;
 };
 
 #endif // TIMELINECELLS_H


### PR DESCRIPTION
Given the original issue:
> Have the "gutter line" be an accurate representation of where the layer will be positioned when dragging and dropping above or below a reference layer.
image