### PR TITLE
Suggested improvements for layer swapping

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -974,9 +974,9 @@ void Editor::switchVisibilityOfLayer(int layerNumber)
     emit updateTimeLine();
 }
 
-void Editor::moveLayer(int i, int j)
+void Editor::swapLayers(int i, int j)
 {
-    mObject->moveLayer(i, j);
+    mObject->swapLayers(i, j);
     if (j < i)
     {
         layers()->setCurrentLayer(j);

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -138,7 +138,7 @@ public: //slots
     void removeKey();
 
     void switchVisibilityOfLayer(int layerNumber);
-    void moveLayer(int i, int j);
+    void swapLayers(int i, int j);
 
     void backup(QString undoText);
     void backup(int layerNumber, int frameNumber, QString undoText);

--- a/core_lib/src/interface/timelinecells.h
+++ b/core_lib/src/interface/timelinecells.h
@@ -45,6 +45,7 @@ public:
     ~TimeLineCells();
 
     int getLayerNumber(int y);
+    int getInbetweenLayerNumber(int y);
     int getLayerY(int layerNumber);
     int getFrameNumber(int x);
     int getFrameX(int frameNumber);
@@ -107,7 +108,6 @@ private:
 
     int mFromLayer = 0;
     int mToLayer   = 1;
-    int mDragType  = 1;
     int mStartLayerNumber = -1;
     int mStartFrameNumber = 0;
     int mLastFrameNumber = -1;

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -241,7 +241,7 @@ Layer* Object::findLayerByName(QString strName, Layer::LAYER_TYPE type) const
     return nullptr;
 }
 
-bool Object::moveLayer(int i, int j)
+bool Object::swapLayers(int i, int j)
 {
     if (i < 0 || i >= mLayers.size())
     {

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -114,7 +114,7 @@ public:
     Layer* getLayer(int i) const;
     Layer* findLayerByName(QString strName, Layer::LAYER_TYPE type = Layer::UNDEFINED) const;
 
-    bool moveLayer(int i, int j);
+    bool swapLayers(int i, int j);
     void deleteLayer(int i);
     void deleteLayer(Layer*);
 


### PR DESCRIPTION
Changes:
- Layers move to closest space (or put differently, dragging to the bottom half of one item is the same as dragging to the top half of the next item)
- Refactor moveLayer to swapLayers to better convey its purpose.
- Eliminate the need for a temporary layer