### PR TITLE
#1106: Doxygen comments + dialog layout

### DIFF
--- a/app/src/copymultiplekeyframesdialog.h
+++ b/app/src/copymultiplekeyframesdialog.h
@@ -25,13 +25,13 @@ public:
     explicit CopyMultiplekeyframesDialog(LayerManager *lm, int startLoop = 1, int stopLoop = 2, QWidget *parent = nullptr);
     ~CopyMultiplekeyframesDialog();
     void init();
-    int getFirstFrame() { return mFirstFrame; }             // first frame in range
-    int getLastFrame() { return mLastFrame; }               // last frame in range
-    QString getFromLayer() { return mFromLayer; }           // Layer thet holds the Range
-    QString getCopyToLayer() { return mCopyToLayer; }       // Layer that receives Copy Range
-    QString getMoveToLayer() { return mMoveToLayer; }       // Layer the Range is moved to
-    int getNumLoops() { return mNumLoops; }                 // Number of loops asked for
-    int getCurrentTab() { return mCurrentTab; }             // Tab/Method currently picked
+    int getFirstFrame() { return mFirstFrame; }             ///< first frame in range
+    int getLastFrame() { return mLastFrame; }               ///< last frame in range
+    QString getFromLayer() { return mFromLayer; }           ///< Layer thet holds the Range
+    QString getCopyToLayer() { return mCopyToLayer; }       ///< Layer that receives Copy Range
+    QString getMoveToLayer() { return mMoveToLayer; }       ///< Layer the Range is moved to
+    int getNumLoops() { return mNumLoops; }                 ///< Number of loops asked for
+    int getCurrentTab() { return mCurrentTab; }             ///< Tab/Method currently picked
     int getCopyStartFrame();
     int getMoveStartFrame();
     int getReverseStartFrame();
@@ -59,21 +59,21 @@ private slots:
 private:
     Ui::CopyMultiplekeyframesDialog *ui;
 
-    int mCurrentTab;        // Index of current tab
-    int mFirstFrame;        // Frame# that starts loop
-    int mLastFrame;         // Frame# that ends loop
-    int mNumLoops;          // Number of loops
-    int mCopyStart;         // Frame# to insert first copied frame
-    int mMoveStart;         // Frame# to insert first moved frame
-    int mReverseStart;      // Frame# to insert first reversed frame
-    int mManiStartAt;       // First frame affected of change
-    int mManiEndAt;         // Last frame affected of change
+    int mCurrentTab;        ///< Index of current tab
+    int mFirstFrame;        ///< Frame# that starts loop
+    int mLastFrame;         ///< Frame# that ends loop
+    int mNumLoops;          ///< Number of loops
+    int mCopyStart;         ///< Frame# to insert first copied frame
+    int mMoveStart;         ///< Frame# to insert first moved frame
+    int mReverseStart;      ///< Frame# to insert first reversed frame
+    int mManiStartAt;       ///< First frame affected of change
+    int mManiEndAt;         ///< Last frame affected of change
 
-    bool mValidAction;      // Validity of desired action
+    bool mValidAction;      ///< Validity of desired action
 
-    QString mFromLayer;     // name of From Layer
-    QString mCopyToLayer;   // name of To Layer you copy to
-    QString mMoveToLayer;   // name of To Layer you move to
+    QString mFromLayer;     ///< name of From Layer
+    QString mCopyToLayer;   ///< name of To Layer you copy to
+    QString mMoveToLayer;   ///< name of To Layer you move to
     QString mLabWarning;
     LayerManager *lMgr;
 

--- a/app/ui/copymultiplekeyframesdialog.ui
+++ b/app/ui/copymultiplekeyframesdialog.ui
@@ -7,26 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>344</width>
-    <height>448</height>
+    <height>412</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Manipulate multiple Frames</string>
+   <string>Manipulate Multiple Frames</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="leftMargin">
-    <number>2</number>
-   </property>
-   <property name="topMargin">
-    <number>4</number>
-   </property>
-   <property name="rightMargin">
-    <number>2</number>
-   </property>
-   <property name="bottomMargin">
-    <number>4</number>
-   </property>
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0" colspan="2">
     <widget class="QLabel" name="labHeader">
      <property name="font">
       <font>
@@ -35,283 +23,24 @@
       </font>
      </property>
      <property name="text">
-      <string>Manipulate Range of frames</string>
+      <string>Manipulate Range of Frames</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="labRangeStart">
-       <property name="text">
-        <string>First Frame:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="sBoxFirstFrame">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>9999</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="labRangeEnd">
-       <property name="text">
-        <string>Last Frame:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="sBoxLastFrame">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>9999</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="labFromLayer">
-       <property name="text">
-        <string>From Layer:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cBoxFromLayer"/>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>0</number>
+   <item row="4" column="1">
+    <widget class="QSpinBox" name="sBoxFirstFrame">
+     <property name="minimum">
+      <number>1</number>
      </property>
-     <widget class="QWidget" name="tabCopy">
-      <attribute name="title">
-       <string>Copy</string>
-      </attribute>
-      <widget class="QWidget" name="layoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>6</x>
-         <y>11</y>
-         <width>321</width>
-         <height>100</height>
-        </rect>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QLabel" name="labNumLoops">
-            <property name="text">
-             <string>Number of loops:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="sBoxNumLoops">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>4999</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <widget class="QLabel" name="labCopyFromFrame">
-            <property name="text">
-             <string>From frame:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="sBoxStartFrame">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>9999</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
-          <item>
-           <widget class="QLabel" name="labCopyToLayer">
-            <property name="text">
-             <string>To layer:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cBoxCopyToLayer"/>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-     <widget class="QWidget" name="tabMove">
-      <attribute name="title">
-       <string>Move</string>
-      </attribute>
-      <widget class="QWidget" name="layoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>6</x>
-         <y>10</y>
-         <width>321</width>
-         <height>67</height>
-        </rect>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
-          <item>
-           <widget class="QLabel" name="labMoveFromFrame">
-            <property name="text">
-             <string>From frame:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="sBoxMove">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>9999</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_8">
-          <item>
-           <widget class="QLabel" name="labMoveToLayer">
-            <property name="text">
-             <string>To layer</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cBoxMoveToLayer"/>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-     <widget class="QWidget" name="tabReverse">
-      <attribute name="title">
-       <string>Reverse</string>
-      </attribute>
-      <widget class="QWidget" name="layoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>9</x>
-         <y>11</y>
-         <width>321</width>
-         <height>26</height>
-        </rect>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="labReverseFromFrame">
-          <property name="text">
-           <string>From frame:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="sBoxStartReverse">
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>9999</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-     <widget class="QWidget" name="tabDelete">
-      <attribute name="title">
-       <string>Delete</string>
-      </attribute>
-      <widget class="QLabel" name="labDeleteOnLayer">
-       <property name="geometry">
-        <rect>
-         <x>7</x>
-         <y>11</y>
-         <width>271</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>On layer:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="labInfoAction">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
+     <property name="maximum">
+      <number>9999</number>
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QLabel" name="labInfoToFromLayer">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
+   <item row="13" column="0" colspan="2">
     <widget class="QLabel" name="labWarning">
      <property name="font">
       <font>
@@ -327,7 +56,33 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="12" column="0" colspan="2">
+    <widget class="QLabel" name="labInfoToFromLayer">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QLabel" name="labInfoAction">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="btnBoxOkCancel">
      <property name="layoutDirection">
       <enum>Qt::LeftToRight</enum>
@@ -337,6 +92,225 @@
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="labRangeStart">
+     <property name="text">
+      <string>First Frame:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tabCopy">
+      <attribute name="title">
+       <string>Copy</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="1" column="0">
+        <widget class="QLabel" name="labCopyFromFrame">
+         <property name="text">
+          <string>From frame:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QSpinBox" name="sBoxStartFrame">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>9999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labNumLoops">
+         <property name="text">
+          <string>Number of loops:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="sBoxNumLoops">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>4999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="cBoxCopyToLayer"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="labCopyToLayer">
+         <property name="text">
+          <string>To layer:</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabMove">
+      <attribute name="title">
+       <string>Move</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <widget class="QLabel" name="labMoveFromFrame">
+         <property name="text">
+          <string>From frame:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="sBoxMove">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>9999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labMoveToLayer">
+         <property name="text">
+          <string>To layer</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="cBoxMoveToLayer"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabReverse">
+      <attribute name="title">
+       <string>Reverse</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="0" column="0">
+        <widget class="QLabel" name="labReverseFromFrame">
+         <property name="text">
+          <string>From frame:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="sBoxStartReverse">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>9999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabDelete">
+      <attribute name="title">
+       <string>Delete</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="0" column="0">
+        <widget class="QLabel" name="labDeleteOnLayer">
+         <property name="text">
+          <string>On layer:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QSpinBox" name="sBoxLastFrame">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>9999</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="labRangeEnd">
+     <property name="text">
+      <string>Last Frame:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QComboBox" name="cBoxFromLayer"/>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="labFromLayer">
+     <property name="text">
+      <string>From Layer:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
When I looked over your most recent changes to the dialog, I noticed it still wasn’t quite consistent. When I dug deeper I discovered that fixing that was actually more tricky than I originally thought (and also that I actually hate Qt Designer), so I went ahead and figured out how to do it myself. Essentially I switched to grid layouts everywhere and removed all the "standalone" layouts, in particular in the tab pane where I set the layouts directly on the tab pane widgets themselves rather than adding them as children. However, doing that is so extremely counter-intuitive in Qt Designer that I'd almost consider it a bug (and this is probably also why you didn’t do it that way yourself): To set the layout on a tab pane, you have to change the current tab of the tab widget to the one whose layout you want to change, then you need to make sure that the tab widget is selected (and not the tab *pane* widget), and if you then select one of the layouts the designer will set it on the active tab pane.

Secondly, I believe it’s still not entirely clear to you how to utilise those Doxygen comments, and it’s probably my fault for not explaining it better. Basically, the purpose of those comments is to generate the documentation at <https://www.pencil2d.org/pencil-docs/docs/>. As you can see, that documentation is consists of a few text pages (which are actually generated from Markdown files in docs/) on one hand and references for all the classes in the project on the other hand. Doxygen can automatically read all the classes and their members and such from the source code, but to actually document them, it needs those specially formatted comments. That’s why I asked you to format them accordingly, however not all comments are useful for Doxygen. Since it only generates documentation for the interfaces (i.e. classes, their attributes and methods, the parameters of those methods, etc.) but not the code that runs “behind the scenes”, comments inside „regular code” (i.e. ifs, loops, function calls etc.) can (and should) simply use regular comments.

Here’s an example of how the documentation currently looks with the changes in this PR:
![screenshot_2019-01-22 pencil2d copymultiplekeyframesdialog class reference](https://user-images.githubusercontent.com/2063777/51554514-c369ab80-1e75-11e9-9b9d-b304abfe2ecb.png)
![screenshot_2019-01-22 pencil2d copymultiplekeyframesdialog class reference2](https://user-images.githubusercontent.com/2063777/51554568-e1cfa700-1e75-11e9-814c-f9f682613656.png)

If you have questions, let me know.