### PR TITLE
Decouple GUI from editor

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1376,6 +1376,8 @@ void MainWindow2::importPalette()
 void MainWindow2::makeConnections(Editor* editor)
 {
     connect(editor, &Editor::updateBackup, this, &MainWindow2::updateSaveState);
+    connect(editor, &Editor::needDisplayInfo, this, &MainWindow2::displayMessageBox);
+    connect(editor, &Editor::needDisplayInfoNoTitle, this, &MainWindow2::displayMessageBoxNoTitle);
 }
 
 void MainWindow2::makeConnections(Editor* editor, ColorBox* colorBox)
@@ -1523,4 +1525,14 @@ void MainWindow2::alignPegs()
         }
         closePegReg();
     }
+}
+
+void MainWindow2::displayMessageBox(const QString& title, const QString& body)
+{
+    QMessageBox::information(this, tr(qPrintable(title)), tr(qPrintable(body)), QMessageBox::Ok);
+}
+
+void MainWindow2::displayMessageBoxNoTitle(const QString& body)
+{
+    QMessageBox::information(this, nullptr, tr(qPrintable(body)), QMessageBox::Ok);
 }

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -96,6 +96,9 @@ public:
 
     PreferencesDialog* getPrefDialog() { return mPrefDialog; }
 
+    void displayMessageBox(const QString& title, const QString& body);
+    void displayMessageBoxNoTitle(const QString& body);
+
 Q_SIGNALS:
     void updateRecentFilesList(bool b);
 

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -23,11 +23,8 @@ GNU General Public License for more details.
 #include <QClipboard>
 #include <QTimer>
 #include <QImageReader>
-#include <QFileDialog>
-#include <QInputDialog>
 #include <QDragEnterEvent>
 #include <QDropEvent>
-#include <QMessageBox>
 
 #include "object.h"
 #include "objectdata.h"
@@ -1107,19 +1104,16 @@ Status::StatusInt Editor::pegBarAlignment(QStringList layers)
             {
                 img = layerbitmap->getBitmapImageAtFrame(k);
                 retLeft = img->findLeft(rect, 121);
+                const QString body = tr("Peg bar not found at %1, %2").arg(layerbitmap->name()).arg(k);
                 if (retLeft.errorcode == Status::FAIL)
                 {
-                    QMessageBox::information(nullptr, nullptr,
-                                             tr("Peg bar not found at %1, %2").arg(layerbitmap->name()).arg(k),
-                                             QMessageBox::Ok);
+                    emit needDisplayInfoNoTitle(body);
                     return retLeft;
                 }
                 retRight = img->findTop(rect, 121);
                 if (retRight.errorcode == Status::FAIL)
                 {
-                    QMessageBox::information(nullptr, nullptr,
-                                             tr("Peg bar not found at %1, %2").arg(layerbitmap->name()).arg(k),
-                                             QMessageBox::Ok);
+                    emit needDisplayInfoNoTitle(body);
                     return retRight;
                 }
                 img->moveTopLeft(QPoint(img->left() + (peg_x - retLeft.value), img->top() + (peg_y - retRight.value)));

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -122,6 +122,8 @@ Q_SIGNALS:
     void currentFrameChanged(int n);
 
     void needSave();
+    void needDisplayInfo(const QString& title, const QString& body);
+    void needDisplayInfoNoTitle(const QString& body);
 
 public: //slots
     void clearCurrentFrame();


### PR DESCRIPTION
This adds a method in MainWindow2 that can be emitted from Core, so that we can fire GUI related messages but only when there's an interface to interact with.