### PR TITLE
Rework and refactor

### DIFF
--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -158,18 +158,8 @@ void ImportImageSeqDialog::setSpace(int number)
     uiOptionsBox->spaceSpinBox->setValue(number);
 }
 
-void ImportImageSeqDialog::importArbitrarySequence(int index)
+void ImportImageSeqDialog::importArbitrarySequence()
 {
-    QPointF currentView = mEditor->view()->translation();
-    if (index == 1)
-    {
-        mEditor->view()->resetView();
-    }
-    else if (index == 2)
-    {
-        mEditor->view()->translate(mEditor->view()->getCameraView());
-    }
-
     QStringList files = getFilePaths();
     int number = getSpace();
 
@@ -230,7 +220,6 @@ void ImportImageSeqDialog::importArbitrarySequence(int index)
                              QMessageBox::Ok);
     }
 
-    mEditor->view()->translate(currentView);
 
     emit notifyAnimationLengthChanged();
     progress.close();
@@ -307,17 +296,8 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     return setParams;
 }
 
-void ImportImageSeqDialog::importPredefinedSet(int index)
+void ImportImageSeqDialog::importPredefinedSet()
 {
-    QPointF currentView = mEditor->view()->translation();
-    if (index == 1)
-    {
-        mEditor->view()->resetView();
-    }
-    else if (index == 2)
-    {
-        mEditor->view()->translate(mEditor->view()->getCameraView());
-    }
     PredefinedKeySet keySet = generatePredefinedKeySet();
 
     // Show a progress dialog, as this can take a while if you have lots of images.
@@ -350,8 +330,6 @@ void ImportImageSeqDialog::importPredefinedSet(int index)
 
         if (!ok) { return;}
     }
-
-    mEditor->view()->translate(currentView);
 
     emit notifyAnimationLengthChanged();
 }

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -53,8 +53,8 @@ public:
                                   ImportCriteria importCriteria = ImportCriteria::Arbitrary);
     ~ImportImageSeqDialog() override;
 
-    void importArbitrarySequence(int index);
-    void importPredefinedSet(int index);
+    void importArbitrarySequence();
+    void importPredefinedSet();
     int getSpace();
 
     void setCore(Editor* editor) { mEditor = editor; }

--- a/app/src/importpositiondialog.cpp
+++ b/app/src/importpositiondialog.cpp
@@ -1,20 +1,66 @@
 #include "importpositiondialog.h"
 #include "ui_importpositiondialog.h"
 
+#include "editor.h"
+#include "viewmanager.h"
+
+#include "scribblearea.h"
+
 ImportPositionDialog::ImportPositionDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ImportPositionDialog)
 {
     ui->setupUi(this);
 
-    ui->cbImagePosition->addItem("Current view and position");
-    ui->cbImagePosition->addItem("Canvas centre");
-    ui->cbImagePosition->addItem("Current camera view");
+    ui->cbImagePosition->addItem(tr("Center of canvas"));
+    ui->cbImagePosition->addItem(tr("Center of active camera"));
 
-    connect(ui->cbImagePosition, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ImportPositionDialog::setPosIndex);
+    connect(ui->cbImagePosition, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ImportPositionDialog::didChangeComboBoxIndex);
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ImportPositionDialog::changeImportView);
+
+    QSettings settings(PENCIL2D, PENCIL2D);
+    int value = settings.value(IMPORT_REPOSITION_TYPE).toInt();
+
+    ui->cbImagePosition->setCurrentIndex(value);
+    didChangeComboBoxIndex(value);
 }
 
 ImportPositionDialog::~ImportPositionDialog()
 {
     delete ui;
+}
+
+void ImportPositionDialog::didChangeComboBoxIndex(const int index)
+{
+    switch (index) {
+    case 0: {
+        mImportOption = ImportPositionType::CenterOfCanvas;
+        break;
+    }
+    case 1: {
+        mImportOption = ImportPositionType::CenterOfCamera;
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void ImportPositionDialog::changeImportView()
+{
+    QTransform transform;
+    if (mImportOption == ImportPositionType::CenterOfCanvas)
+    {
+        QPointF centralPoint = mEditor->getScribbleArea()->getCentralPoint();
+        transform = transform.fromTranslate(centralPoint.x(), centralPoint.y());
+    }
+    else if (mImportOption == ImportPositionType::CenterOfCamera)
+    {
+        QRectF cameraRect = mEditor->getScribbleArea()->getCameraRect();
+        transform = transform.fromTranslate(cameraRect.center().x(), cameraRect.center().y());
+    }
+    mEditor->view()->setImportView(transform);
+
+    QSettings settings(PENCIL2D, PENCIL2D);
+    settings.setValue(IMPORT_REPOSITION_TYPE, ui->cbImagePosition->currentIndex());
 }

--- a/app/src/importpositiondialog.cpp
+++ b/app/src/importpositiondialog.cpp
@@ -32,29 +32,18 @@ ImportPositionDialog::~ImportPositionDialog()
 
 void ImportPositionDialog::didChangeComboBoxIndex(const int index)
 {
-    switch (index) {
-    case 0: {
-        mImportOption = ImportPositionType::CenterOfCanvas;
-        break;
-    }
-    case 1: {
-        mImportOption = ImportPositionType::CenterOfCamera;
-        break;
-    }
-    default:
-        break;
-    }
+    mImportOption = ImportPosition::getTypeFromIndex(index);
 }
 
 void ImportPositionDialog::changeImportView()
 {
     QTransform transform;
-    if (mImportOption == ImportPositionType::CenterOfCanvas)
+    if (mImportOption == ImportPosition::Type::CenterOfCanvas)
     {
         QPointF centralPoint = mEditor->getScribbleArea()->getCentralPoint();
         transform = transform.fromTranslate(centralPoint.x(), centralPoint.y());
     }
-    else if (mImportOption == ImportPositionType::CenterOfCamera)
+    else if (mImportOption == ImportPosition::Type::CenterOfCamera)
     {
         QRectF cameraRect = mEditor->getScribbleArea()->getCameraRect();
         transform = transform.fromTranslate(cameraRect.center().x(), cameraRect.center().y());

--- a/app/src/importpositiondialog.h
+++ b/app/src/importpositiondialog.h
@@ -7,6 +7,13 @@ namespace Ui {
 class ImportPositionDialog;
 }
 
+enum class ImportPositionType {
+    CenterOfCamera,
+    CenterOfCanvas
+};
+
+class Editor;
+
 class ImportPositionDialog : public QDialog
 {
     Q_OBJECT
@@ -15,13 +22,17 @@ public:
     explicit ImportPositionDialog(QWidget *parent = nullptr);
     ~ImportPositionDialog();
 
-    int getPosIndex() { return mPosIndex; }
-    void setPosIndex(int index) { mPosIndex = index; }
+    void setCore(Editor* editor) { mEditor = editor; }
+
+private slots:
+    void didChangeComboBoxIndex(const int index);
+    void changeImportView();
 
 private:
     Ui::ImportPositionDialog *ui;
 
-    int mPosIndex = 0;
+    ImportPositionType mImportOption = ImportPositionType::CenterOfCamera;
+    Editor* mEditor = nullptr;
 };
 
 #endif // IMPORTPOSITIONDIALOG_H

--- a/app/src/importpositiondialog.h
+++ b/app/src/importpositiondialog.h
@@ -7,16 +7,31 @@ namespace Ui {
 class ImportPositionDialog;
 }
 
-enum class ImportPositionType {
-    CenterOfCamera,
-    CenterOfCanvas
-};
-
 class Editor;
 
 class ImportPositionDialog : public QDialog
 {
     Q_OBJECT
+
+    struct ImportPosition {
+
+        enum Type {
+            CenterOfCamera,
+            CenterOfCanvas,
+            None
+        };
+
+        static Type getTypeFromIndex(int index) {
+            switch (index) {
+                case 0:
+                    return CenterOfCanvas;
+                case 1:
+                    return CenterOfCamera;
+                default:
+                    return None;
+            }
+        }
+    };
 
 public:
     explicit ImportPositionDialog(QWidget *parent = nullptr);
@@ -31,7 +46,7 @@ private slots:
 private:
     Ui::ImportPositionDialog *ui;
 
-    ImportPositionType mImportOption = ImportPositionType::CenterOfCamera;
+    ImportPosition::Type mImportOption;
     Editor* mEditor = nullptr;
 };
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -781,18 +781,6 @@ bool MainWindow2::autoSave()
     return false;
 }
 
-int MainWindow2::getImportPosition()
-{
-    ImportPositionDialog* positionDialog = new  ImportPositionDialog(this);
-    positionDialog->exec();
-    if (positionDialog->result() == QDialog::Rejected)
-    {
-        return -1;
-    }
-
-    return positionDialog->getPosIndex();
-}
-
 void MainWindow2::importImage()
 {
     FileDialog fileDialog(this);
@@ -801,16 +789,15 @@ void MainWindow2::importImage()
     if (strFilePath.isEmpty()) { return; }
     if (!QFile::exists(strFilePath)) { return; }
 
-    int index = getImportPosition();
-    if (index < 0) { return; }
-    QPointF currentView = mEditor->view()->translation();
-    if (index == 1)
+    ImportPositionDialog* positionDialog = new ImportPositionDialog(this);
+    OnScopeExit(delete positionDialog)
+
+    positionDialog->setCore(mEditor);
+    positionDialog->exec();
+
+    if (positionDialog->result() != QDialog::Accepted)
     {
-        mEditor->view()->resetView();
-    }
-    else if (index == 2)
-    {
-        mEditor->view()->translate(mEditor->view()->getCameraView());
+        return;
     }
 
     bool ok = mEditor->importImage(strFilePath);
@@ -824,7 +811,6 @@ void MainWindow2::importImage()
         return;
     }
 
-    mEditor->view()->translate(currentView);
 
     ui->scribbleArea->updateCurrentFrame();
     mTimeLine->updateContent();
@@ -846,15 +832,15 @@ void MainWindow2::importImageSequence()
         return;
     }
 
-    ImportPositionDialog* positionDialog = new  ImportPositionDialog(this);
+    ImportPositionDialog* positionDialog = new ImportPositionDialog(this);
+    positionDialog->setCore(mEditor);
     positionDialog->exec();
     if (positionDialog->result() == QDialog::Rejected)
     {
         return;
     }
 
-    int index = positionDialog->getPosIndex();
-    imageSeqDialog->importArbitrarySequence(index);
+    imageSeqDialog->importArbitrarySequence();
 
     mIsImportingImageSequence = false;
 }
@@ -881,8 +867,7 @@ void MainWindow2::importPredefinedImageSet()
         return;
     }
 
-    int index = positionDialog->getPosIndex();
-    imageSeqDialog->importPredefinedSet(index);
+    imageSeqDialog->importPredefinedSet();
     mIsImportingImageSequence = false;
 }
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -79,7 +79,6 @@ public:
     bool autoSave();
 
     // import
-    int getImportPosition();
     void importImage();
     void importImageSequence();
     void importPredefinedImageSet();

--- a/app/ui/importpositiondialog.ui
+++ b/app/ui/importpositiondialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>304</width>
-    <height>101</height>
+    <height>102</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <item>
       <widget class="QLabel" name="labImagePosition">
        <property name="text">
-        <string>Import image(-s) relative to:</string>
+        <string>Import image/s relative to:</string>
        </property>
       </widget>
      </item>

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -793,6 +793,8 @@ bool Editor::importBitmapImage(QString filePath, int space)
         return false;
     }
 
+    const QPoint pos = QPoint(static_cast<int>(view()->getImportView().dx()),
+                              static_cast<int>(view()->getImportView().dy())) - QPoint(img.width() / 2, img.height() / 2);
     while (reader.read(&img))
     {
         if (!layer->keyExists(currentFrame()))
@@ -800,8 +802,7 @@ bool Editor::importBitmapImage(QString filePath, int space)
             addNewKey();
         }
         BitmapImage* bitmapImage = layer->getBitmapImageAtFrame(currentFrame());
-
-        BitmapImage importedBitmapImage(mScribbleArea->getCentralPoint().toPoint() - QPoint(img.width() / 2, img.height() / 2), img);
+        BitmapImage importedBitmapImage(pos, img);
         bitmapImage->paste(&importedBitmapImage);
 
         if (space > 1) {

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -360,12 +360,3 @@ void ViewManager::resetView()
         Q_EMIT viewFlipped();
     }
 }
-
-QPointF ViewManager::getCameraView()
-{
-    if (mCurrentCamera)
-    {
-        return mCurrentCamera->translation();
-    }
-    return QPointF(0.0 , 0.0);
-}

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -42,8 +42,6 @@ public:
     QTransform getViewInverse();
     void resetView();
 
-    QPointF getCameraView();
-
     QPointF mapCanvasToScreen(QPointF p);
     QPointF mapScreenToCanvas(QPointF p);
 
@@ -84,6 +82,9 @@ public:
     void setCanvasSize(QSize size);
     void setCameraLayer(Layer* layer);
 
+    QTransform getImportView() { return mImportView; }
+    void setImportView(const QTransform& newView) { mImportView = newView; }
+
     void updateViewTransforms();
 
     Q_SIGNAL void viewChanged();
@@ -98,6 +99,7 @@ private:
     QTransform mViewCanvas;
     QTransform mViewCanvasInverse;
     QTransform mCentre;
+    QTransform mImportView;
 
     Camera* mDefaultEditorCamera = nullptr;
     Camera* mCurrentCamera = nullptr;

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -168,6 +168,9 @@ enum StabilizationLevel
 // Save / Export
 #define LAST_PCLX_PATH          "LastFilePath"
 
+// Import
+#define IMPORT_REPOSITION_TYPE      "ImportRepositionType"
+
 // Settings Group/Key Name
 #define PENCIL2D "Pencil"
 #define SHORTCUTS_GROUP             "Shortcuts"


### PR DESCRIPTION
Hey

I initially began commenting on the PR but after a while I realised that it might need a bit of a clean up, that's why I decided to make a PR :)

Basically I've separated much of the UI logic so that the new import logic does not spill into related import methods. Instead all logic happens from inside ImportPositionDialog. 

Now you only have to pass the qtransform data from UI to view manager, then editor can grab the coordinates and that's it.