### PR TITLE
Pr 1292 changes

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -39,6 +39,7 @@ INCLUDEPATH += \
 
 HEADERS += \
     src/importlayersdialog.h \
+    src/keyframetextedit.h \
     src/mainwindow2.h \
     src/predefinedsetmodel.h \
     src/pegbaralignmentdialog.h \
@@ -72,6 +73,7 @@ HEADERS += \
 
 SOURCES += \
     src/importlayersdialog.cpp \
+    src/keyframetextedit.cpp \
     src/main.cpp \
     src/mainwindow2.cpp \
     src/predefinedsetmodel.cpp \

--- a/app/src/framecommentwidget.cpp
+++ b/app/src/framecommentwidget.cpp
@@ -110,6 +110,7 @@ void FrameCommentWidget::updateConnections()
 void FrameCommentWidget::fillComments()
 {
     KeyFrame* keyframe = getKeyFrame();
+    if (keyframe == nullptr) { return; }
 
     ui->textEditDialogue->setPlainText(keyframe->getDialogueComment());
     ui->textEditAction->setPlainText(keyframe->getActionComment());
@@ -119,6 +120,7 @@ void FrameCommentWidget::fillComments()
 void FrameCommentWidget::applyComments()
 {
     KeyFrame* keyframe = getKeyFrame();
+    if (keyframe == nullptr) { return; }
 
     keyframe->setDialogueComment(ui->textEditDialogue->toPlainText());
     keyframe->setActionComment(ui->textEditAction->toPlainText());

--- a/app/src/framecommentwidget.h
+++ b/app/src/framecommentwidget.h
@@ -51,7 +51,6 @@ private:
     bool mIsPlaying = false;
 
     Editor* mEditor = nullptr;
-
 };
 
 #endif // FRAMECOMMENTWIDGET_H

--- a/app/src/framecommentwidget.h
+++ b/app/src/framecommentwidget.h
@@ -3,9 +3,10 @@
 
 #include <QWidget>
 #include "basedockwidget.h"
-#include "editor.h"
-#include "keyframe.h"
-#include "layer.h"
+
+class Editor;
+class KeyFrame;
+class Layer;
 
 namespace Ui {
     class FrameComment;
@@ -24,9 +25,9 @@ public:
     void setCore(Editor* editor);
 
 public slots:
-    void dialogueTextChanged(QString text);
-    void actionTextChanged(QString text);
-    void notesTextChanged(QString text);
+    void dialogueTextChanged();
+    void actionTextChanged();
+    void notesTextChanged();
     void currentFrameChanged(int frame);
     void currentLayerChanged(int index);
     void clearFrameCommentsFields();
@@ -38,8 +39,8 @@ private:
     Ui::FrameComment *ui;
 
     void fillFrameComments();
-    void connectAll();
-    void disconnectAll();
+    void makeConnections();
+    void disconnectNotifiers();
 
     bool mIsPlaying = false;
 

--- a/app/src/framecommentwidget.h
+++ b/app/src/framecommentwidget.h
@@ -24,29 +24,33 @@ public:
     void updateUI() override;
     void setCore(Editor* editor);
 
-public slots:
-    void dialogueTextChanged();
-    void actionTextChanged();
-    void notesTextChanged();
-    void currentFrameChanged(int frame);
-    void currentLayerChanged(int index);
-    void clearFrameCommentsFields();
-    void applyFrameComments();
-    void playStateChanged(bool isPlaying);
-    void updateConnections();
+    void applyComments();
+    void fillComments();
 
 private:
     Ui::FrameComment *ui;
 
-    void fillFrameComments();
+    void dialogueTextChanged();
+    void actionTextChanged();
+    void slugTextChanged();
+
+    void currentFrameChanged(int frame);
+    void currentLayerChanged(int index);
+
+    void clearFrameCommentsFields();
+
+    void updateConnections();
+
+    void playStateChanged(bool isPlaying);
+
+    KeyFrame* getKeyFrame();
+
     void makeConnections();
     void disconnectNotifiers();
 
     bool mIsPlaying = false;
 
     Editor* mEditor = nullptr;
-    Layer* mLayer = nullptr;
-    KeyFrame* mKeyframe = nullptr;
 
 };
 

--- a/app/src/keyframetextedit.cpp
+++ b/app/src/keyframetextedit.cpp
@@ -1,0 +1,13 @@
+#include "keyframetextedit.h"
+
+KeyFrameTextEdit::KeyFrameTextEdit(QWidget* parent) : QPlainTextEdit(parent) {
+
+}
+
+void KeyFrameTextEdit::focusOutEvent(QFocusEvent *event) {
+
+    if (event->lostFocus()) {
+        emit(lostFocus());
+    }
+    QPlainTextEdit::focusOutEvent(event);
+}

--- a/app/src/keyframetextedit.h
+++ b/app/src/keyframetextedit.h
@@ -1,0 +1,20 @@
+#ifndef KEYFRAMETEXTEDIT_H
+#define KEYFRAMETEXTEDIT_H
+
+#include <QPlainTextEdit>
+
+class KeyFrameTextEdit : public QPlainTextEdit {
+
+    Q_OBJECT
+public:
+    KeyFrameTextEdit(QWidget* parent = nullptr);
+
+Q_SIGNALS:
+    void lostFocus();
+
+protected:
+    void focusOutEvent(QFocusEvent *e) override;
+
+};
+
+#endif // KEYFRAMETEXTEDIT_H

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -199,12 +199,11 @@ void MainWindow2::createDockWidgets()
     addDockWidget(Qt::RightDockWidgetArea, mColorBox);
     addDockWidget(Qt::RightDockWidgetArea, mColorInspector);
     addDockWidget(Qt::RightDockWidgetArea, mColorPalette);
-    addDockWidget(Qt::RightDockWidgetArea, mFrameComments);
-    mFrameComments->hide();
     addDockWidget(Qt::LeftDockWidgetArea, mToolBox);
     addDockWidget(Qt::LeftDockWidgetArea, mToolOptions);
     addDockWidget(Qt::LeftDockWidgetArea, mDisplayOptionWidget);
     addDockWidget(Qt::BottomDockWidgetArea, mTimeLine);
+
     setDockNestingEnabled(true);
 
     /*

--- a/app/ui/framecommentwidget.ui
+++ b/app/ui/framecommentwidget.ui
@@ -30,23 +30,9 @@
     <number>4</number>
    </property>
    <item>
-    <widget class="QLabel" name="labMax100chars">
-     <property name="text">
-      <string>Max 250 chars each!</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="labDialogue">
+      <widget class="QLabel" name="labelDialogue">
        <property name="text">
         <string>Dialogue:</string>
        </property>
@@ -66,7 +52,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="labDialogueCount">
+      <widget class="QLabel" name="labelDialogueCounter">
        <property name="text">
         <string>0</string>
        </property>
@@ -75,16 +61,12 @@
     </layout>
    </item>
    <item>
-    <widget class="QLineEdit" name="leDialogue">
-     <property name="maxLength">
-      <number>250</number>
-     </property>
-    </widget>
+    <widget class="KeyFrameTextEdit" name="textEditDialogue"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLabel" name="labAction">
+      <widget class="QLabel" name="labelAction">
        <property name="text">
         <string>Action:</string>
        </property>
@@ -104,7 +86,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="labActionCount">
+      <widget class="QLabel" name="labelActionCounter">
        <property name="text">
         <string>0</string>
        </property>
@@ -113,16 +95,12 @@
     </layout>
    </item>
    <item>
-    <widget class="QLineEdit" name="leAction">
-     <property name="maxLength">
-      <number>250</number>
-     </property>
-    </widget>
+    <widget class="KeyFrameTextEdit" name="textEditAction"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <widget class="QLabel" name="labNotes">
+      <widget class="QLabel" name="labelSlug">
        <property name="text">
         <string>Slug (Timing, Camera, ...)</string>
        </property>
@@ -142,7 +120,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="labNotesCount">
+      <widget class="QLabel" name="labelSlugCounter">
        <property name="text">
         <string>0</string>
        </property>
@@ -151,11 +129,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QLineEdit" name="leNotes">
-     <property name="maxLength">
-      <number>250</number>
-     </property>
-    </widget>
+    <widget class="KeyFrameTextEdit" name="textEditSlug"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -181,76 +155,15 @@
      </item>
     </layout>
    </item>
-   <item>
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_6">
-     <item>
-      <widget class="QLabel" name="labLayerFrame">
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_6">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <spacer name="horizontalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnApplyComments">
-       <property name="text">
-        <string>Apply comments</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>117</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>KeyFrameTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header>keyframetextedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -502,7 +502,9 @@ void FileManager::loadFrameComments(Object *obj, QDomElement &element)
 {
     Layer* layer = nullptr;
     KeyFrame* key = nullptr;
-    int index, newindex = -1;
+
+    int newLayerIndex = -1;
+    int oldLayerIndex = -1;
 
     for(QDomNode tag = element.firstChild(); !tag.isNull(); tag = tag.nextSibling())
     {
@@ -511,13 +513,14 @@ void FileManager::loadFrameComments(Object *obj, QDomElement &element)
         {
             continue;
         }
-        // get layer index
-        index = comments.tagName().remove(0, 5).toInt();
 
-        // get layer
-        if (index != newindex)
-        {
-            layer = obj->getLayer(index);
+        oldLayerIndex = comments.attribute("layer").toInt();
+        if (newLayerIndex != oldLayerIndex) {
+            layer = obj->getLayer(oldLayerIndex);
+        }
+
+        if (layer == nullptr) {
+            continue;
         }
 
         // get keyFrame
@@ -528,7 +531,8 @@ void FileManager::loadFrameComments(Object *obj, QDomElement &element)
         key->setDialogueComment(comments.attribute("dialogue"));
         key->setActionComment(comments.attribute("action"));
         key->setSlugComment(comments.attribute("slug"));
-        newindex = index;
+
+        newLayerIndex = oldLayerIndex;
     }
 }
 
@@ -541,7 +545,7 @@ QDomElement FileManager::saveFrameComments(Object* obj, QDomDocument &xmlDoc)
     for (int i = 0; i < layers; i++)
     {
         Layer* layer = obj->getLayer(i);
-        QString tag = "index" + QString::number(i);
+        QString tag = "content";
         int frame = layer->firstKeyFramePosition();
         do
         {
@@ -549,6 +553,7 @@ QDomElement FileManager::saveFrameComments(Object* obj, QDomDocument &xmlDoc)
             if (key->frameHasComments())
             {
                 QDomElement tagComments = xmlDoc.createElement(tag);
+                tagComments.setAttribute("layer", i);
                 tagComments.setAttribute("frame", frame);
                 tagComments.setAttribute("dialogue", key->getDialogueComment());
                 tagComments.setAttribute("action", key->getActionComment());


### PR DESCRIPTION
Hey David

I've made some changes to the PR, mainly to fix some nasty inconsistent crashes I experienced, seemingly because you keep reference of keyframe and layer but at some point those references are not accessible in memory anymore. In general I didn't see the need to add that complexity for now and therefore removed those variables, we can optimise later if neccesary.

I've changed the text edit widget to a variation of QPlainTextEdit, mainly to get multiple lines but also by creating my own class derived from QPlainTextEdit, we can now update the fields based on its focus event. This means that the apply button becomes redundant because it will update whenever you leave the widget, eg. click no the canvas, change tool etc...

A few things to note:
1. Unless you initialise a class object in the header eg. Keyframe keyframe and not KeyFrame* keyframe, you should use forward declaration and declare the include in the source file instead, this can make a big difference in compile time as the header has to recompile every time but the class can be cached.

2. Avoid stuff like this:
```c++
comments.tagName().remove(0, 5).toInt();
```
it's hacky, instead create a tag and use that attribute, like you did previously.

3. Unless you know a method should be accessible from another class, keep the method private. This makes it much easier to understand when to use what and where.

Thanks for taking the initiative to make this, I hope you find my comments helpful :)