### PR TITLE
Some memeory management things about PCLX import crash

### DIFF
--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -26,6 +26,8 @@ ImportLayersDialog::ImportLayersDialog(QWidget *parent) :
     connect(ui->btnClose, &QPushButton::clicked, this, &ImportLayersDialog::cancel);
     ui->lwLayers->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->btnImportLayers->setEnabled(false);
+
+    hideQuestionMark(*this);
 }
 
 ImportLayersDialog::~ImportLayersDialog()

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -38,7 +38,6 @@ ImportLayersDialog::~ImportLayersDialog()
 void ImportLayersDialog::setCore(Editor *editor)
 {
     mEditor = editor;
-    mObject = mEditor->object();
 }
 
 void ImportLayersDialog::getFileName()
@@ -68,6 +67,7 @@ void ImportLayersDialog::listWidgetChanged()
 
 void ImportLayersDialog::importLayers()
 {
+    Object* object = mEditor->object();
     int currentFrame = mEditor->currentFrame();
     for (int i = 0; i < mImportObject->getLayerCount(); i++ )
     {
@@ -87,11 +87,11 @@ void ImportLayersDialog::importLayers()
                     Status st = mEditor->sound()->loadSound(clip, clip->fileName());
                     count = newKeyPos;
                 }
-                mObject->addLayer(layerSound);
+                object->addLayer(layerSound);
             }
             else
             {
-                mObject->addLayer(mImportLayer);
+                object->addLayer(mImportLayer);
             }
             mEditor->object()->modification();
         }

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -80,6 +80,8 @@ void ImportLayersDialog::importLayers()
 
             mImportLayer = mImportObject->takeLayer(layerId);
             mImportLayer->setName(mEditor->layers()->nameSuggestLayer(item->text()));
+            loadKeyFrames(mImportLayer); // all keyframes of this layer must be in memory
+
             object->addLayer(mImportLayer);
 
             if (mImportLayer->type() == Layer::SOUND)
@@ -144,4 +146,15 @@ void ImportLayersDialog::getLayers()
         item->setData(Qt::UserRole, layerId);
         ui->lwLayers->addItem(item);
     }
+}
+
+void ImportLayersDialog::loadKeyFrames(Layer* importedLayer)
+{
+    // Pencil2D only keeps a small portion of keyframes in the memory initially
+    // Here we need to force load all the keyframes of this layer into memory
+    // Otherwise the keyframe data will lose after mImportObject is deleted
+    importedLayer->foreachKeyFrame([](KeyFrame* k)
+    {
+        k->loadFile();
+    });
 }

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -76,7 +76,9 @@ void ImportLayersDialog::importLayers()
         QListWidgetItem* item = ui->lwLayers->item(i);
         if (item->isSelected())
         {
-            mImportLayer = mImportObject->findLayerByName(item->text());
+            int layerId = item->data(Qt::UserRole).toInt();
+
+            mImportLayer = mImportObject->takeLayer(layerId);
             mImportLayer->setName(mEditor->layers()->nameSuggestLayer(item->text()));
             object->addLayer(mImportLayer);
 

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -133,6 +133,13 @@ void ImportLayersDialog::getLayers()
 
     ui->lwLayers->clear();
     for (int i = 0; i < mImportObject->getLayerCount(); i++)
-        ui->lwLayers->addItem(mImportObject->getLayer(i)->name());
+    {
+        const QString layerName = mImportObject->getLayer(i)->name();
+        const int layerId = mImportObject->getLayer(i)->id();
 
+        // Store the layer name as well as layer ID cuz two layers could have the same name
+        QListWidgetItem* item = new QListWidgetItem(layerName);
+        item->setData(Qt::UserRole, layerId);
+        ui->lwLayers->addItem(item);
+    }
 }

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -97,7 +97,7 @@ void ImportLayersDialog::importLayers()
     }
     mEditor->object()->modification();
 
-    mImportObject = nullptr;
+    mImportObject.reset();
     getLayers();
     mEditor->scrubTo(currentFrame);
 }
@@ -129,7 +129,7 @@ void ImportLayersDialog::getLayers()
     {
         progress.setRange(0, max + 3);
     });
-    mImportObject = fm.load(mFileName);
+    mImportObject.reset(fm.load(mFileName));
 
     ui->lwLayers->clear();
     for (int i = 0; i < mImportObject->getLayerCount(); i++)

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -69,12 +69,17 @@ void ImportLayersDialog::importLayers()
 {
     Object* object = mEditor->object();
     int currentFrame = mEditor->currentFrame();
-    for (int i = 0; i < mImportObject->getLayerCount(); i++ )
+    Q_ASSERT(ui->lwLayers->count() == mImportObject->getLayerCount());
+
+    for (int i = 0; i < ui->lwLayers->count(); i++ )
     {
-        if (ui->lwLayers->item(i)->isSelected())
+        QListWidgetItem* item = ui->lwLayers->item(i);
+        if (item->isSelected())
         {
-            mImportLayer = mImportObject->findLayerByName(ui->lwLayers->item(i)->text());
-            mImportLayer->setName(mEditor->layers()->nameSuggestLayer(ui->lwLayers->item(i)->text()));
+            mImportLayer = mImportObject->findLayerByName(item->text());
+            mImportLayer->setName(mEditor->layers()->nameSuggestLayer(item->text()));
+            object->addLayer(mImportLayer);
+
             if (mImportLayer->type() == Layer::SOUND)
             {
                 LayerSound* layerSound = static_cast<LayerSound*>(mImportLayer);
@@ -87,15 +92,11 @@ void ImportLayersDialog::importLayers()
                     Status st = mEditor->sound()->loadSound(clip, clip->fileName());
                     count = newKeyPos;
                 }
-                object->addLayer(layerSound);
             }
-            else
-            {
-                object->addLayer(mImportLayer);
-            }
-            mEditor->object()->modification();
         }
     }
+    mEditor->object()->modification();
+
     mImportObject = nullptr;
     getLayers();
     mEditor->scrubTo(currentFrame);

--- a/app/src/importlayersdialog.h
+++ b/app/src/importlayersdialog.h
@@ -30,7 +30,7 @@ private:
 
     void getLayers();
 
-    Object *mImportObject = nullptr;
+    std::unique_ptr<Object> mImportObject;
     Layer* mImportLayer = nullptr;
     Editor* mEditor = nullptr;
     QString mFileName;

--- a/app/src/importlayersdialog.h
+++ b/app/src/importlayersdialog.h
@@ -30,11 +30,10 @@ private:
 
     void getLayers();
 
-    Object *mObject = nullptr;
     Object *mImportObject = nullptr;
     Layer* mImportLayer = nullptr;
     Editor *mEditor = nullptr;
-    QString mFileName = "";
+    QString mFileName;
     QList<int> mItemsSelected;
 };
 

--- a/app/src/importlayersdialog.h
+++ b/app/src/importlayersdialog.h
@@ -35,6 +35,7 @@ private:
     Editor* mEditor = nullptr;
     QString mFileName;
     QList<int> mItemsSelected;
+    void loadKeyFrames(Layer* importedLayer);
 };
 
 #endif // IMPORTLAYERSDIALOG_H

--- a/app/src/importlayersdialog.h
+++ b/app/src/importlayersdialog.h
@@ -32,7 +32,7 @@ private:
 
     Object *mImportObject = nullptr;
     Layer* mImportLayer = nullptr;
-    Editor *mEditor = nullptr;
+    Editor* mEditor = nullptr;
     QString mFileName;
     QList<int> mItemsSelected;
 };

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 
 Pencil - Traditional Animation Software
 Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
@@ -919,9 +919,10 @@ void MainWindow2::importPredefinedImageSet()
 
 void MainWindow2::importLayers()
 {
-    ImportLayersDialog *importLayers = new ImportLayersDialog(this);
+    ImportLayersDialog* importLayers = new ImportLayersDialog(this);
     importLayers->setCore(mEditor);
-    importLayers->exec();
+    importLayers->setAttribute(Qt::WA_DeleteOnClose);
+    importLayers->open();
 }
 
 void MainWindow2::importGIF()

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -31,15 +31,15 @@ bool sortAsc(int left, int right)
     return left < right;
 }
 
-Layer::Layer(Object* pObject, LAYER_TYPE eType) : QObject(pObject)
+Layer::Layer(Object* object, LAYER_TYPE eType) : QObject(object)
 {
     Q_ASSERT(eType != UNDEFINED);
 
-    mObject = pObject;
+    mObject = object;
     meType = eType;
     mName = QString(tr("Undefined Layer"));
 
-    mId = pObject->getUniqueLayerID();
+    mId = object->getUniqueLayerID();
 }
 
 Layer::~Layer()
@@ -50,6 +50,14 @@ Layer::~Layer()
         delete pKeyFrame;
     }
     mKeyFrames.clear();
+}
+
+void Layer::setObject(Object* obj)
+{
+    Q_ASSERT(obj);
+    mObject = obj;
+    setParent(mObject);
+    mId = mObject->getUniqueLayerID();
 }
 
 void Layer::foreachKeyFrame(std::function<void(KeyFrame*)> action)

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -55,9 +55,10 @@ public:
     virtual ~Layer();
 
     int id() const { return mId; }
-
     LAYER_TYPE type() const { return meType; }
+
     Object* object() const { return mObject; }
+    void setObject(Object* obj);
 
     void setName(QString name) { mName = name; }
     QString name() const { return mName; }

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -308,12 +308,19 @@ void Object::deleteLayer(Layer* layer)
     }
 }
 
-void Object::addLayer(Layer *layer)
+bool Object::addLayer(Layer* layer)
 {
-    if (layer != nullptr)
+    if (layer == nullptr)
     {
-        mLayers.append(layer);
+        return false;
     }
+    if (mLayers.contains(layer))
+    {
+        return false;
+    }
+    layer->setObject(this);
+    mLayers.append(layer);
+    return true;
 }
 
 ColorRef Object::getColor(int index) const

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -246,6 +246,28 @@ Layer* Object::findLayerByName(QString strName, Layer::LAYER_TYPE type) const
     return nullptr;
 }
 
+Layer* Object::takeLayer(int layerId)
+{
+    // Removes the layer from this Object and returns it
+    // The ownership of this layer has been transfer to the caller
+    int index = -1;
+    for (int i = 0; i< mLayers.length(); ++i)
+    {
+        Layer* layer = mLayers[i];
+        if (layer->id() == layerId)
+        {
+            index = i;
+            break;
+        }
+    }
+
+    if (index == -1) { return nullptr; }
+
+    Layer* layer = mLayers.takeAt(index);
+    layer->setParent(nullptr);
+    return layer;
+}
+
 bool Object::swapLayers(int i, int j)
 {
     if (i < 0 || i >= mLayers.size())

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -116,6 +116,7 @@ public:
     int  getLayerCount() const;
     Layer* getLayer(int i) const;
     Layer* findLayerByName(QString strName, Layer::LAYER_TYPE type = Layer::UNDEFINED) const;
+    Layer* takeLayer(int layerId); // Note: transfer ownership of the layer
 
     bool swapLayers(int i, int j);
     void deleteLayer(int i);

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -121,7 +121,7 @@ public:
     bool swapLayers(int i, int j);
     void deleteLayer(int i);
     void deleteLayer(Layer*);
-    void addLayer(Layer* layer);
+    bool addLayer(Layer* layer);
 
     template<typename T>
     std::vector<T*> getLayersByType() const


### PR DESCRIPTION
Hey David,

I made some changes to this PR. Generally they are memory management things for PCLX import feature.

1. Using std::unique_ptr to manage `mImportObjet`
2. Implemented the ownership transfer of a layer between two objects
3. Import layer by LayerId rather than layer name (prevent same name layers)
4. Load all key frames into memory when importing the layer.

Please see each commits for the details